### PR TITLE
Quick fix for the README file

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ import { scanImageData } from '@undecaf/zbar-wasm';
           // @ts-ignore
           symbols = await scanImageData(imageData);
 
-  console.log(ssymbols[0]?.typeName, ymbols[0]?.decode())
+  console.log(symbols[0]?.typeName, symbols[0]?.decode())
 })('https://raw.githubusercontent.com/undecaf/zbar-wasm/master/tests/img/qr_code.png')
 ```
 


### PR DESCRIPTION
The getting started example for NodeJS had a typo